### PR TITLE
fixed styling with long words and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenResponse
 
-🧠💻 This project is a small prompt-completion application built with Open-AI's GPT-3 (DaVinci) and Next.js. Users can enter prompts of any complexity and expect a response in text form. This application does not collect or store any data.
+🧠 💻 This project is a small prompt-completion application built with Open-AI's GPT-3 (DaVinci) and Next.js. Users can enter prompts of any complexity and expect a response in text form. This application does not collect or store any data.
 
 ## Technology
 

--- a/components/elements/dialoguebox/Dialogue.module.css
+++ b/components/elements/dialoguebox/Dialogue.module.css
@@ -104,7 +104,7 @@
     display: flex;
     flex-direction: column;
     padding-top: 3px;
-    width: 93%;
+    width: 90%;
 }
 
 .dialogue-divider {
@@ -122,6 +122,7 @@
     font-family: Monaco;
     font-size: 24px;
     color: #B5B4FF;
+    word-wrap: break-word;
     -webkit-font-smoothing: antialiased;
 }
 
@@ -168,8 +169,8 @@
     .openresponse-input-logo {
         width: 21px;
         height: 21px;
-        margin-left: 10px;
-        margin-right: 4px;
+        margin-left: 9px;
+        margin-right: 0px;
         min-width: unset;
     }
 
@@ -182,11 +183,14 @@
 
     .response-text-wrapper {
         padding: 0;
-        width: 100%;
+        /* width: 100%; */
+        width: 90%;
+        padding-left: 0.4em;
     }
 
     .openresponse-text {
         font-size: 16px;
         max-width: 97%;
+        word-wrap: break-word;
     }
 }

--- a/components/elements/dialoguebox/TypingPlaceholder.module.css
+++ b/components/elements/dialoguebox/TypingPlaceholder.module.css
@@ -53,6 +53,7 @@
 
 @media (max-width: 600px) {
     .typing {
+        padding-left: 0.4em;
         height: 25px;
     }
 }


### PR DESCRIPTION
# Changes

- added word wrapping to prevent long words and links from overflowing the designated text box. e.g. `word-wrap: breakword`
- `TypingPlaceholder` now has a padding to be in line with respective input textarea